### PR TITLE
add initial view of the idh model mixin for label creation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,30 @@
+name: Create release PR
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  create-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4.0.2
+        with:
+          release-type: python
+          package-name: release-please-action
+          prerelease: false
+          default-branch: main
+          extra-files: |
+            "pyproject.toml"
+          version-file: pyproject.toml
+          changelog-types: '[
+          {"type":"feat","section":"Features","hidden":false},
+          {"type":"fix","section":"Bug Fixes","hidden":false},
+          {"type":"chore","section":"Miscellaneous","hidden":false},
+          {"type":"perf","section":"Performance improvements","hidden":false}
+          ]'

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -3,7 +3,7 @@ name: Create release PR
 on:
   push:
     branches:
-      - main
+      - "main"
 
 permissions:
   contents: write
@@ -11,20 +11,4 @@ permissions:
 
 jobs:
   create-release-pr:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: google-github-actions/release-please-action@v4.0.2
-        with:
-          release-type: python
-          package-name: release-please-action
-          prerelease: false
-          default-branch: main
-          extra-files: |
-            "pyproject.toml"
-          version-file: pyproject.toml
-          changelog-types: '[
-          {"type":"feat","section":"Features","hidden":false},
-          {"type":"fix","section":"Bug Fixes","hidden":false},
-          {"type":"chore","section":"Miscellaneous","hidden":false},
-          {"type":"perf","section":"Performance improvements","hidden":false}
-          ]'
+    uses: telicent-oss/shared-workflows/.github/workflows/python-create-release-pr.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,52 +9,71 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Build distribution
-    runs-on: ubuntu-latest
+  test:
+    name: Python Tests
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.11", "3.12"]
+    uses: telicent-oss/shared-workflows/.github/workflows/python-ci-qa.yml@main
+    with:
+      PYTHON_VERSION: ${{ matrix.python-version }}
+      SKIP_BUILD: true
 
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.x"
+  get-version:
+    uses: telicent-oss/shared-workflows/.github/workflows/python-get-version-number.yml@main
 
-    - name: Install pypa/build
-      run: >-
-        python3 -m
-        pip install
-        build
-        --user
-
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-
-    - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
-      with:
-        name: python-package-distributions
-        path: dist/
+  build-pypi-pkg:
+    name: Prepare and Build Release
+    uses: telicent-oss/shared-workflows/.github/workflows/python-build-pypi-pkg.yml@main
+    needs:
+      - get-version
+    with:
+      PACKAGE: telicent_labels
+      VERSION: ${{ needs.get-version.outputs.version }}
 
   publish-to-pypi:
     name: Publish Python distribution to PyPI
     needs:
-    - build
+    - build-pypi-pkg
+    - test
     runs-on: ubuntu-latest
-
     environment:
       name: pypi
       url: https://pypi.org/p/telicent-label-builder
-
     permissions:
       id-token: write
-
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
+        name: ${{ needs.build-pypi-pkg.outputs.application-sbom-artifact-name }}-dist
         path: dist/
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+
+  do-github-release:
+    name: Do GitHub Release
+    uses: telicent-oss/shared-workflows/.github/workflows/python-gh-release.yml@main
+    needs:
+      - get-version
+      - test
+      - build-pypi-pkg
+    with:
+      VERSION: ${{ needs.get-version.outputs.version }}
+
+  attach-sboms-to-release:
+    name: Attach SBOMs to release
+    needs:
+      - do-github-release
+      - get-version
+      - build-pypi-pkg
+    strategy:
+      matrix:
+        sbom-artifacts:
+         - ${{ needs.build-pypi-pkg.outputs.application-sbom-artifact-name }}
+    uses: telicent-oss/shared-workflows/.github/workflows/python-attach-sbom-to-release.yml@main
+    with:
+      SBOM_ARTIFACT: ${{ matrix.sbom-artifacts }}
+      VERSION: ${{ needs.get-version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+name: Release to PyPI
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "CHANGELOG.md"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/telicent-label-builder
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-test-build.yml
+++ b/.github/workflows/python-test-build.yml
@@ -1,0 +1,20 @@
+name: Python Test Build
+
+on:
+  pull_request:
+    branches:
+      - "release-please*"
+  push:
+    branches-ignore:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  test_and_build:
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    uses: telicent-oss/shared-workflows/.github/workflows/python-test-library.yml@main
+    with:
+      PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/python-test-build.yml
+++ b/.github/workflows/python-test-build.yml
@@ -10,11 +10,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_and_build:
+  test-and-build:
+    name: Python Test and Build
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
-    uses: telicent-oss/shared-workflows/.github/workflows/python-test-library.yml@main
+        python-version: ["3.11", "3.12"]
+    uses: telicent-oss/shared-workflows/.github/workflows/python-ci-qa.yml@main
     with:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/scan-prs.yml
+++ b/.github/workflows/scan-prs.yml
@@ -1,0 +1,11 @@
+name: Python Vuln Scan
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  scan_pr:
+    uses: telicent-oss/shared-workflows/.github/workflows/python-generate-and-scan-application.yml@main
+    with:
+      SCAN_NAME: ${{ github.run_number }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,141 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+requirements.txt
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs_old/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+venv*/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# OS X
+.DS_Store
+
+# IntelliJ
+.idea/
+site/
+
+#Ruff
+.ruff_cache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+---
+repos:
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.14
+    hooks:
+      - id: validate-pyproject
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.3
+    hooks:
+      - id: ruff
+        args: [--no-cache]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.2](https://github.com/telicent-oss/label-builder/compare/v0.1.1...v0.1.2) (2024-08-09)
+
+
+### Miscellaneous
+
+* meta class for telicent mixin expose api functionality docs ([#6](https://github.com/telicent-oss/label-builder/issues/6)) ([9e6eada](https://github.com/telicent-oss/label-builder/commit/9e6eadaae178b14b45b0da9143b84e52a0584aa1))
+* update release pr to reusable workflow ([#7](https://github.com/telicent-oss/label-builder/issues/7)) ([b5db659](https://github.com/telicent-oss/label-builder/commit/b5db659b1663c9cfe96084a2a4f577e34ada5fda))
+
 ## [0.1.1](https://github.com/telicent-oss/label-builder/compare/v0.1.0...v0.1.1) (2024-06-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.5](https://github.com/telicent-oss/label-builder/compare/v0.1.4...v0.1.5) (2024-08-21)
+
+
+### Miscellaneous
+
+* update min version for label-builder-service ([#14](https://github.com/telicent-oss/label-builder/issues/14)) ([8db639e](https://github.com/telicent-oss/label-builder/commit/8db639ec53ae666299965db610a168408e573842))
+
 ## [0.1.4](https://github.com/telicent-oss/label-builder/compare/v0.1.3...v0.1.4) (2024-08-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.1.0 (2024-05-10)
+
+
+### Features
+
+* initial release of telicent label builder ([59ffe1b](https://github.com/telicent-oss/label-builder/commit/59ffe1bd54aae57ab62175e8065e0fc9e86bc4b2))
+
 ## 0.1.0 (2024-05-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0 (2024-05-07)
+
+
+### Features
+
+* Initial release of label builder ([255903f](https://github.com/telicent-oss/label-builder/commit/255903f327573e7caf1f0f3b91cbf86aadf9e595))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.3](https://github.com/telicent-oss/label-builder/compare/v0.1.2...v0.1.3) (2024-08-14)
+
+
+### Miscellaneous
+
+* update dependency ([#10](https://github.com/telicent-oss/label-builder/issues/10)) ([beaf53e](https://github.com/telicent-oss/label-builder/commit/beaf53ed34042f7ff70ffd0161e34536f43d9162))
+
 ## [0.1.2](https://github.com/telicent-oss/label-builder/compare/v0.1.1...v0.1.2) (2024-08-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.4](https://github.com/telicent-oss/label-builder/compare/v0.1.3...v0.1.4) (2024-08-20)
+
+
+### Bug Fixes
+
+* pin minimum version of label-builder-service to prevent issues ([#12](https://github.com/telicent-oss/label-builder/issues/12)) ([0bbcdcb](https://github.com/telicent-oss/label-builder/commit/0bbcdcb802d26176ed88c0995da87ece268be60b))
+
 ## [0.1.3](https://github.com/telicent-oss/label-builder/compare/v0.1.2...v0.1.3) (2024-08-14)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.1.1](https://github.com/telicent-oss/label-builder/compare/v0.1.0...v0.1.1) (2024-06-27)
+
+
+### Documentation
+
+* update documentation to reflect recent changes to telicent-lib ([8482299](https://github.com/telicent-oss/label-builder/commit/84822998a0445c672cb9f17742bfc963794948da))
+* update documentation to reflect recent changes to telicent-lib ([#4](https://github.com/telicent-oss/label-builder/issues/4)) ([8482299](https://github.com/telicent-oss/label-builder/commit/84822998a0445c672cb9f17742bfc963794948da))
+
 ## 0.1.0 (2024-05-10)
 
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 TELICENT LTD
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+telicent-label-builder
+============
+
+Copyright (c) 2024 Telicent Ltd.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# telicent-label-builder
+
+
+Telicent label builder provides useful helper classes to build and create security labels.
+
+## Dependencies
+
+- Python \>=3.10
+- Pydantic
+
+## Installation
+
+```shell
+pip install telicent-label-builder
+```
+
+## Usage
+
+For documentation on how to use telicent-label-builder, please see the [documentation index](docs/index.md).

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -1,0 +1,3 @@
+python3 -m pip install --upgrade pip
+python3 -m pip install pip-tools
+python3 -m piptools compile --extra dev -o requirements.txt pyproject.toml

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,4 +11,10 @@ model in a data processing context.
 
 3. [Telicent Model Implementation](./telicent-header)
    - Implementation details of the Telicent model, which integrates with the Security Label Builder.
+   - Description of TelicentMixin used to create customer defined models validating data headers.
    - Code example demonstrating the application of Telicent policy in automatic adapters.
+
+4. [Telicent Model Rest Service](./model-as-a-service.md)
+   - Information on wrapping a model around a rest service.
+   - Code examples.
+   

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+Documentation covers the implementation and usage of the Security Label Builder, Telicent Enums, and the Telicent default
+model in a data processing context.
+
+1. [Label Builder](./label-builder.md)
+   - Overview and implementation of the Security Label Builder.
+   - Usage examples for creating and managing security labels.
+
+2. [Telicent Enums](./telicent-enums)
+   - Enumerations based on the default Telicent model.
+   - Detailed explanation of different label types like `MultiValueLabel` and `SingleValueLabel`.
+
+3. [Telicent Model Implementation](./telicent-header)
+   - Implementation details of the Telicent model, which integrates with the Security Label Builder.
+   - Code example demonstrating the application of Telicent policy in automatic adapters.

--- a/docs/label-builder.md
+++ b/docs/label-builder.md
@@ -1,0 +1,74 @@
+### Security Label Builder
+
+#### Overview
+
+The Security Label Builder is designed to construct security label expressions. It supports single or multiple value 
+labels and allows for complex expressions using logical OR and AND operations. 
+
+#### Classes
+
+1. **Label**: Base class for labels in a Security Label Expression.
+   - `__init__(self, name: str, label_type: str)`: Initializes a label with a name and type.
+   - `create_label(self, value)`: Returns a label expression.
+   - `construct(self, *values)`: Abstract method for constructing label expressions.
+   
+    A label represents an element within a Security Label Expression.
+
+    It is used to define possible labels within a schema, specifically
+    dictating how the label is created and importantly defining a construct
+    function to be used as part of the Builder pattern
+
+2. **MultiValueLabel (inherits Label)**: Allows multiple values in a label, typically using OR logic.
+   - `construct(self, *values)`: Constructs a label expression with multiple values using OR logic.
+    
+     A data label which can take on multiple values in an expression, usually using an OR logic
+   
+3. **SingleValueLabel (inherits Label)**: Restricts to a single value in a label.
+   - `construct(self, *values)`: Constructs a label expression with a single value. Raises error if multiple values are provided.
+
+4. **SecurityLabelHelper**: Abstract class providing a structure for label manipulation.
+   - `add(self, label: SingleValueLabel, value: str)`: Abstract method for adding a single label expression.
+   - `add_multiple(self, label: MultiValueLabel, *values)`: Abstract method for adding multiple label expressions.
+   - `add_or_expression(self, expression: str)`: Abstract method for adding complex expressions using OR logic.
+   - `build(self) -> str`: Abstract method for building the final expression.
+   
+5. **SecurityLabelBuilder (inherits SecurityLabelHelper)**: Core class for creating valid Security Label expressions.
+   - `__init__(self)`: Initializes the builder with empty label sets and expressions.
+   - `add(self, label: Label, value: str)`: Adds a label expression. Warns if the label is already used.
+   - `add_multiple(self, label: MultiValueLabel, *values)`: Adds a label expression with multiple values.
+   - `add_or_expression(self, expression: str)`: Adds an OR expression. Validates the syntax.
+   - `build(self)`: Constructs the final Security Label expression.
+   
+   Method calls can be chained until build is run. 
+
+#### Usage Examples
+
+1. **Creating a Single Value Label**
+   ```python
+   confidentiality_label = SingleValueLabel("confidentiality", "data_type")
+   builder = SecurityLabelBuilder()
+   builder.add(confidentiality_label, "classified")
+   label_expression = builder.build()
+   ```
+2. **Creating Multi Value Label**
+  ```python
+  access_label = MultiValueLabel("access", "user_type")
+  builder = SecurityLabelBuilder()
+  builder.add_multiple(access_label, "admin", "user")
+  label_expression = builder.build()
+  ```
+3. Adding OR Expressions
+   ```python
+   builder = SecurityLabelBuilder()
+   builder.add_or_expression("(confidentiality=classified)")
+   builder.add_or_expression("(access=admin|user)")
+   complex_label_expression = builder.build()
+   ```
+
+The label builder could be used with any data, a fully working example can be found under `telicent_labels/telicent_model.py`,
+data validation is enforced by enums which reference labels and model which verifies the user inputs.
+
+In the context of default policy, the label builder would extract a subset of data from Telicent Policy/Model, the fields of interest described
+by an enum are then passed to the builder where they get transformed to a fully valid label representation that can
+be evaluated by Access.
+

--- a/docs/model-as-a-service.md
+++ b/docs/model-as-a-service.md
@@ -1,0 +1,67 @@
+### Telicent Model Rest Service
+
+#### Overview
+
+Telicent Security Labels provides a functionality to run given model as a rest service, the default behaviour is
+aligned with the example Telicent Model. As long as user defined model implements logic to build security labels, it
+will be made available as an endpoint under `localhost:8000/api/v1/ingest` where a data header can be posted and
+API would respond with the generated security labels.
+
+For further information and advanced use cases, please refer to [telicent-label-builder-service](https://github.com/telicent-oss/label-builder-service/blob/main/README.md)
+
+> ### ⚠️ Warning
+> telicent-label-builder-service provides [telicent-lib](https://github.com/telicent-oss/telicent-lib) as a dependency.
+> telicent-label-builder-service is a dependency of this project!
+> telicent-label-builder-service is configurable only through environment variables for the moment.
+
+
+Assuming the model we want to wrap around REST API is [TelicentModel](../telicent_labels/telicent_model.py) a minimal
+program to run the REST service and perform validation would look like the following:
+
+```python
+from telicent_labels import TelicentModel
+
+if __name__ == '__main__':
+    TelicentModel.run_api()
+
+```
+
+The code above would start the rest service with default values, see `telicent-label-builder-service` documentation.
+It would allow us to use the ingest endpoint like so:
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/ingest" \
+-H "Content-Type: application/json" \
+-d '{
+  "identifier": "ItemA",
+  "classification": "S",
+  "permittedOrgs": [
+    "ABC",
+    "DEF",
+    "HIJ"
+  ],
+  "permittedNats": [
+    "GBR",
+    "FRA",
+    "IRL"
+  ],
+  "orGroups": [
+    "Apple",
+    "SOMETHING"
+  ],
+  "andGroups": [
+    "doctor",
+    "admin"
+  ],
+  "originator": "TestOriginator",
+  "custodian": "TestCustodian",
+  "policyRef": "TestPolicyRef",
+  "dataSet": ["ds1", "ds2"],
+  "authRef": ["ref1", "ref2"],
+  "dispositionProcess": "disp-process-1",
+  "dissemination": ["news", "articles"]
+}'
+{"status":"success",
+"security_label":"(classification=S&(permitted_organisations=ABC|permitted_organisations=DEF|permitted_organisations=HIJ)&
+(permitted_nationalities=GBR|permitted_nationalities=FRA|permitted_nationalities=IRL)&doctor:and&admin:and&(Apple:or|SOMETHING:or))"}
+```

--- a/docs/telicent-enums.md
+++ b/docs/telicent-enums.md
@@ -6,6 +6,9 @@ Telicent Security Labels provide enumerations to use with the Security Label Bui
 CORE environment. The system supports multiple and single value labels, 
 as well as complex group logic.
 
+> ### ⚠️ Warning
+> This is conceptual implementation for illustrative purposes built for TelicentModel.
+
 #### Classes and Enums
 
 1. **TelicentSecurityLabelsV1 (Enum)**: Represents a simplified version of the default Telicent model used in the CORE environment.

--- a/docs/telicent-enums.md
+++ b/docs/telicent-enums.md
@@ -1,0 +1,39 @@
+### Telicent Security Labels ENUMS
+
+#### Overview
+
+Telicent Security Labels provide enumerations to use with the Security Label Builder. They define specific default labels for the 
+CORE environment. The system supports multiple and single value labels, 
+as well as complex group logic.
+
+#### Classes and Enums
+
+1. **TelicentSecurityLabelsV1 (Enum)**: Represents a simplified version of the default Telicent model used in the CORE environment.
+   - `PERMITTED_ORGANISATIONS`: A `MultiValueLabel` for specifying multiple allowed organizations.
+   - `PERMITTED_NATIONALITIES`: A `MultiValueLabel` for defining multiple permitted nationalities.
+   - `CLASSIFICATION`: A `SingleValueLabel` for indicating the clearance level.
+
+2. **AndGroups (inherits MultiValueLabel)**: Used for creating conditions where all specified groups must be met (AND logic).
+   - `construct(self, *values)`: Constructs a label expression where all values must be true.
+   - `create_label(self, value: str)`: Formats the value for AND group logic.
+
+3. **OrGroups (inherits MultiValueLabel)**: Used for creating conditions where any of the specified groups must be met (OR logic).
+   - `construct(self, *values)`: Constructs a label expression where any value can be true.
+   - `create_label(self, value: str)`: Formats the value for OR group logic.
+
+4. **TelicentSecurityLabelsV2 (Enum)**: A more comprehensive representation of the .
+   - `PERMITTED_ORGANISATIONS`: A `MultiValueLabel` for multiple allowed organizations.
+   - `PERMITTED_NATIONALITIES`: A `MultiValueLabel` for multiple permitted nationalities.
+   - `CLASSIFICATION`: A `SingleValueLabel` for clearance level.
+   - `AND_GROUPS`: An `AndGroups` label for specifying groups where all conditions must be met.
+   - `OR_GROUPS`: An `OrGroups` label for specifying groups where any condition can be met.
+
+#### Usage Examples
+
+1. **Using TelicentSecurityLabelsV1**
+   ```python
+   builder = SecurityLabelBuilder()
+   builder.add(TelicentSecurityLabelsV1.CLASSIFICATION.value, "TopSecret")
+   builder.add_multiple(TelicentSecurityLabelsV1.PERMITTED_ORGANISATIONS.value, "Org1", "Org2")
+   label_expression = builder.build()
+   ```

--- a/docs/telicent-header.md
+++ b/docs/telicent-header.md
@@ -1,0 +1,107 @@
+### Documentation for Telicent Header Model Implementation
+
+#### Overview
+
+The Telicent Header Model, as part of a data processing pipeline, facilitates the creation and management of security labels. 
+The implementation involves creating a model that dynamically builds 
+security labels, which can then be attached to data records. This process ensures that each record complies with specified 
+security and access policies.
+
+#### Classes 
+
+1. **TelicentMixin Class**: A base model providing the `build_security_labels` method.
+   - `build_security_labels(self)`: Utilizes `SecurityLabelBuilder` and `TelicentSecurityLabelsV2` to construct security labels based on class attributes.
+    
+   The mixin class is designed to enhance the extensibility and versatility of a model. It provides a flexible means to 
+   augment the functionality of the primary model, as well as to offer compatibility and feature support for additional models. 
+   This approach ensures modular and adaptable design, allowing for the seamless integration of extended capabilities or the incorporation of functionalities from other models.
+
+
+2. **TelicentModel Class (inherits TelicentMixin)**: Represents the Telicent policy with various attributes.
+   - Attributes include `identifier`, `classification`, `permittedOrgs`, `permittedNats`, `orGroups`, `andGroups`, and optional fields like `createDate`, `originator`, etc.
+   - `build_security_labels(self)`: Overrides the base method to build security labels specific to this model.
+
+
+#### Example: Using Telicent Header Model with Adapter
+
+```python
+import requests
+from telicent_lib import Adapter
+from telicent_lib.access import TelicentModel
+from telicent_lib.records import Record, RecordUtils
+from telicent_lib.sinks import KafkaSink
+
+def records_from_file() -> list[str]:
+    url = "https://test.com/wordlist.10000"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    lines = resp.text.rstrip().split("\n")
+    return lines
+
+# Create a sink and an adapter
+sink = KafkaSink(topic="adapter-demo", broker="localhost:9092")
+adapter = Adapter(target=sink, name="Demo Adapter with Telicent Policy", source_name="Word List MIT")
+
+telicent_policy = {
+    # Telicent policy details...
+}
+
+security_labels = TelicentModel(**telicent_policy).build_security_labels()
+
+try:
+    adapter.run()
+    adapter.expect_records(10000)
+
+    for i, line in enumerate(records_from_file(), start=1):
+        record = Record(headers=None, key=i, value=line, raw=None)
+        # TEL key is user defined, in future this might change.
+        record_with_headers = RecordUtils.add_headers(record, [('policyInformation', {'TEL': telicent_policy})])
+        record_with_label_and_policy = RecordUtils.add_headers(record_with_headers,
+                                                               [('Security-Label', security_labels)])
+        adapter.send(record_with_label_and_policy)
+
+    adapter.finished()
+except KeyboardInterrupt:
+    adapter.aborted()
+
+if __name__ == '__main__':
+    adapter.run()
+```
+
+#### Usage with Automatic Adapters
+
+Automatic adapters are engineered to seamlessly administer a Telicent Policy across all data records they process. 
+Upon instantiation, these adapters apply a predefined policy, specified in the class constructor, uniformly to every record. 
+This ensures consistent policy enforcement and simplifies the management of data security.
+
+```python
+   import json
+   from pathlib import Path
+   from typing import Iterable
+   from telicent_lib import AutomaticAdapter, Record
+   from telicent_lib.sinks import KafkaSink, Serializers
+   
+   policy = {
+       # Telicent policy details...
+   }
+   
+   def read_json_objects(file_path):
+       path = Path(file_path)
+       with path.open('r', encoding='utf-8') as file:
+           data = json.load(file)
+           if not isinstance(data, list):
+               raise ValueError("JSON file does not contain an array of objects")
+           yield from data
+   
+   def generate_records() -> Iterable[Record]:
+       for i, record in enumerate(read_json_objects("./demo_data.json")):
+           yield Record(headers=None, key=i, value=record, raw=None)
+   
+   sink = KafkaSink(topic="output-automatic-adapter-demo", broker="localhost:9092", value_serializer=Serializers.to_json)
+   adapter = AutomaticAdapter(target=sink, adapter_function=generate_records,
+                              name="Example Automatic Adapter with security policy", source_name="Some file",
+                              policy_information=policy)
+   
+   if __name__ == '__main__':
+       adapter.run()
+```

--- a/docs/telicent-header.md
+++ b/docs/telicent-header.md
@@ -9,17 +9,16 @@ security and access policies.
 
 #### Classes 
 
-1. **TelicentMixin Class**: A base model providing the `build_security_labels` method.
-   - `build_security_labels(self)`: Utilizes `SecurityLabelBuilder` and `TelicentSecurityLabelsV2` to construct security labels based on class attributes.
-    
-   The mixin class is designed to enhance the extensibility and versatility of a model. It provides a flexible means to 
-   augment the functionality of the primary model, as well as to offer compatibility and feature support for additional models. 
-   This approach ensures modular and adaptable design, allowing for the seamless integration of extended capabilities or the incorporation of functionalities from other models.
-
-
+1. **TelicentMixin Class**: An abstract base model providing core functionality
+   - `build_security_labels(self)`: An abstract method that must be implemented by
+      subclasses to utilize the SecurityLabelBuilder for constructing security 
+      labels based on model attributes.
+     
+   - `run_api(cls, custom_router: APIRouter | None = None):` A class method to initiate the API service using the 
+      model's configuration, leveraging the provided run_api_service function. 
+      Please refer to [Running model as a service](./model-as-a-service.md)
 2. **TelicentModel Class (inherits TelicentMixin)**: Represents the Telicent policy with various attributes.
-   - Attributes include `identifier`, `classification`, `permittedOrgs`, `permittedNats`, `orGroups`, `andGroups`, and optional fields like `createDate`, `originator`, etc.
-   - `build_security_labels(self)`: Overrides the base method to build security labels specific to this model.
+   - Pro 
 
 
 #### Example: Using Telicent Header Model with Adapter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telicent-label-builder"
-version = "0.1.4"
+version = "0.1.5"
 authors = [{name = "Telicent Ltd", email = "opensource@telicent.io"}]
 description = "A helper package for creating and building security labels for telicent-lib"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {file = "LICENSE.md"}
 readme = "README.md"
 dependencies = [
     "pydantic",
-    "telicent-label-builder-service>=0.1.1"
+    "telicent-label-builder-service>=0.1.2"
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telicent-label-builder"
-version = "0.1.1"
+version = "0.1.2"
 authors = [{name = "Telicent Ltd", email = "opensource@telicent.io"}]
 description = "A helper package for creating and building security labels for telicent-lib"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {file = "LICENSE.md"}
 readme = "README.md"
 dependencies = [
     "pydantic",
-    "telicent-label-builder-service"
+    "telicent-label-builder-service>=0.1.1"
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,99 @@
+[build-system]
+requires = ["setuptools>=61.2.0", "wheel==0.41.3", "pip-tools==7.3.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "telicent-label-builder"
+version = "0.1.0"
+authors = [{name = "Telicent Ltd", email = "admin@telicent.io"}]
+description = "A helper package for creating and building security labels for telicent-lib"
+requires-python = ">=3.10"
+license = {file = "LICENSE.md"}
+readme = "README.md"
+dependencies = [
+    "pydantic"
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3 :: Only",
+    "Topic :: Software Development",
+    "Typing :: Typed",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Operating System :: MacOS",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pre-commit==3.7.0",
+    "ruff==0.4.2",
+    "mypy==1.10.0"
+]
+
+[tool.setuptools.dynamic]
+readme = {file = ["README.md"]}
+
+[project.urls]
+Repository = "https://github.com/telicent-oss/label-builder"
+Changelog = "https://github.com/telicent-oss/label-builder/blob/main/CHANGELOG.md"
+
+[tool.ruff]
+target-version = "py310"
+lint.select = [
+    "E",  # pycodestyle errors
+    "W",  # pycodestyle warnings
+    "F",  # pyflakes
+    "I",  # isort
+    "C",  # flake8-comprehensions
+    "B",  # flake8-bugbear
+    "UP", # pyupgrade
+]
+lint.ignore = [
+    "C901", # too complex
+]
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+]
+line-length = 120
+
+[tool.distutils.bdist_wheel]
+universal = true
+
+[tool.mypy]
+local_partial_types = true
+no_implicit_optional = false
+ignore_missing_imports = true
+modules = ["telicent_labels", "test"]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["telicent_labels*"]
+namespaces = true
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telicent-label-builder"
-version = "0.1.3"
+version = "0.1.4"
 authors = [{name = "Telicent Ltd", email = "opensource@telicent.io"}]
 description = "A helper package for creating and building security labels for telicent-lib"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {file = "LICENSE.md"}
 readme = "README.md"
 dependencies = [
     "pydantic",
-    "telicent-label-builder-service>=0.1.2"
+    "telicent-label-builder-service>=0.1.3"
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,14 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "telicent-label-builder"
 version = "0.1.1"
-authors = [{name = "Telicent Ltd", email = "admin@telicent.io"}]
+authors = [{name = "Telicent Ltd", email = "opensource@telicent.io"}]
 description = "A helper package for creating and building security labels for telicent-lib"
 requires-python = ">=3.10"
 license = {file = "LICENSE.md"}
 readme = "README.md"
 dependencies = [
-    "pydantic"
+    "pydantic",
+    "telicent-label-builder-service"
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telicent-label-builder"
-version = "0.1.0"
+version = "0.1.1"
 authors = [{name = "Telicent Ltd", email = "admin@telicent.io"}]
 description = "A helper package for creating and building security labels for telicent-lib"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telicent-label-builder"
-version = "0.1.2"
+version = "0.1.3"
 authors = [{name = "Telicent Ltd", email = "opensource@telicent.io"}]
 description = "A helper package for creating and building security labels for telicent-lib"
 requires-python = ">=3.10"

--- a/telicent_labels/__init__.py
+++ b/telicent_labels/__init__.py
@@ -1,0 +1,31 @@
+from telicent_labels.security_labels import Label, MultiValueLabel, SecurityLabelBuilder, SingleValueLabel
+from telicent_labels.telicent_model import TelicentModel
+from telicent_labels.telicentv1 import TelicentLabelsV1
+from telicent_labels.telicentv2 import TelicentSecurityLabelsV2
+
+__license__ = """
+Copyright (c) Telicent Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+__all__ = [
+    "SecurityLabelBuilder",
+    "TelicentSecurityLabelsV2",
+    "TelicentLabelsV1",
+    "MultiValueLabel",
+    "SingleValueLabel",
+    "Label",
+    "TelicentModel",
+]

--- a/telicent_labels/__init__.py
+++ b/telicent_labels/__init__.py
@@ -1,8 +1,8 @@
+from telicent_labels.idh_model import IDHModel
 from telicent_labels.security_labels import Label, MultiValueLabel, SecurityLabelBuilder, SingleValueLabel
 from telicent_labels.telicent_model import TelicentModel
 from telicent_labels.telicentv1 import TelicentLabelsV1
 from telicent_labels.telicentv2 import TelicentSecurityLabelsV2
-from telicent_labels.idh_model import IDHModel
 
 __license__ = """
 Copyright (c) Telicent Ltd.
@@ -30,5 +30,4 @@ __all__ = [
     "Label",
     "IDHModel",
     "TelicentModel",
-    
 ]

--- a/telicent_labels/__init__.py
+++ b/telicent_labels/__init__.py
@@ -2,6 +2,7 @@ from telicent_labels.security_labels import Label, MultiValueLabel, SecurityLabe
 from telicent_labels.telicent_model import TelicentModel
 from telicent_labels.telicentv1 import TelicentLabelsV1
 from telicent_labels.telicentv2 import TelicentSecurityLabelsV2
+from telicent_labels.idh_model import IDHModel
 
 __license__ = """
 Copyright (c) Telicent Ltd.
@@ -27,5 +28,7 @@ __all__ = [
     "MultiValueLabel",
     "SingleValueLabel",
     "Label",
+    "IDHModel",
     "TelicentModel",
+    
 ]

--- a/telicent_labels/idh_model.py
+++ b/telicent_labels/idh_model.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import datetime, timezone
+from typing import Annotated
+
+from pydantic import AwareDatetime, BaseModel, PlainSerializer, field_validator
+
+from telicent_labels.security_labels import SecurityLabelBuilder
+from telicent_labels.telicentv2 import TelicentSecurityLabelsV2
+
+__license__ = """
+Copyright (c) Telicent Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+log = logging.getLogger(__name__)
+
+DEFAULT_OPTIONAL_DT = datetime(2023, 12, 14, 0, 0, 0, tzinfo=timezone.utc)
+SerialisableDt = Annotated[AwareDatetime, PlainSerializer(lambda x: x.isoformat(), return_type=str, when_used="always")]
+
+
+class TelicentMixin(BaseModel):
+    def build_security_labels(self):
+        print(self.creationDate)
+        builder = SecurityLabelBuilder()
+
+        builder.add(TelicentSecurityLabelsV2.CLASSIFICATION.value, self.access.classification)
+        if len(self.access.allowedOrgs) > 0:
+            builder.add_multiple(TelicentSecurityLabelsV2.PERMITTED_ORGANISATIONS.value, *self.access.allowedOrgs)
+        if len(self.access.allowedNats) > 0:
+            builder.add_multiple(TelicentSecurityLabelsV2.PERMITTED_NATIONALITIES.value, *self.access.allowedNats)
+        if len(self.access.groups) > 0:
+            builder.add_multiple(TelicentSecurityLabelsV2.AND_GROUPS.value, *self.access.groups)
+
+        return builder.build()
+
+
+
+class AccessModel(BaseModel):
+    classification: str
+    allowedOrgs: list[str]
+    allowedNats: list[str]
+    groups: list[str]
+
+    @field_validator('classification')
+    def non_empty_string(cls, value: str, info):
+        if value.strip() == "":
+            raise ValueError(f"The {info.field_name} field cannot be an empty string.")
+        if value.strip() not in ("O", "OS", "S", "TS"):
+            raise ValueError(f"The {info.field_name} field must be 'O', 'OS', 'S' or 'TS'.")
+        return value
+    
+
+class OwnershipModel(BaseModel):
+    originatingOrg: str
+    user: str | None = None
+
+class IDHModel(TelicentMixin):
+   
+    apiVersion: str | None = "v1alpha"
+    uuid: str
+    creationDate: SerialisableDt | None = DEFAULT_OPTIONAL_DT
+    containsPii: bool
+    dataSource: str | None = None
+    ownership: OwnershipModel
+    access: AccessModel
+
+    def build_security_labels(self):
+        return super().build_security_labels()

--- a/telicent_labels/idh_model.py
+++ b/telicent_labels/idh_model.py
@@ -31,7 +31,6 @@ SerialisableDt = Annotated[AwareDatetime, PlainSerializer(lambda x: x.isoformat(
 
 class TelicentMixin(BaseModel):
     def build_security_labels(self):
-        print(self.creationDate)
         builder = SecurityLabelBuilder()
 
         builder.add(TelicentSecurityLabelsV2.CLASSIFICATION.value, self.access.classification)
@@ -45,28 +44,27 @@ class TelicentMixin(BaseModel):
         return builder.build()
 
 
-
 class AccessModel(BaseModel):
     classification: str
     allowedOrgs: list[str]
     allowedNats: list[str]
     groups: list[str]
 
-    @field_validator('classification')
+    @field_validator("classification")
     def non_empty_string(cls, value: str, info):
         if value.strip() == "":
             raise ValueError(f"The {info.field_name} field cannot be an empty string.")
         if value.strip() not in ("O", "OS", "S", "TS"):
             raise ValueError(f"The {info.field_name} field must be 'O', 'OS', 'S' or 'TS'.")
         return value
-    
+
 
 class OwnershipModel(BaseModel):
     originatingOrg: str
     user: str | None = None
 
+
 class IDHModel(TelicentMixin):
-   
     apiVersion: str | None = "v1alpha"
     uuid: str
     creationDate: SerialisableDt | None = DEFAULT_OPTIONAL_DT

--- a/telicent_labels/security_labels.py
+++ b/telicent_labels/security_labels.py
@@ -1,0 +1,142 @@
+__license__ = """
+Copyright (c) Telicent Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+class Label:
+
+    """
+    A label represents an element within a Security Label Expression.
+
+    It is used to define possible labels within a schema, specifically
+    dictating how the label is created and importantly defining a construct
+    function to be used as part of the Builder pattern
+    """
+
+    def __init__(self, name: str, label_type: str):
+        self.name = name
+        self.label_type = label_type
+
+    def create_label(self, value):
+        return f"{self.name}={value}"
+
+    def construct(self, *values):
+        raise NotImplementedError()
+
+
+class MultiValueLabel(Label):
+    """
+    The basic implementation for a data label which can take on multiple values
+    in an expression, usually using an OR logic
+    """
+
+    def construct(self, *values):
+        condition = "|".join(map(self.create_label, values))
+        return f"({condition})"
+
+
+class SingleValueLabel(Label):
+    """
+    The basic implementation for a data label which can take on a single label
+    in an expression
+    """
+
+    def construct(self, *values):
+        if len(values) > 1:
+            raise ValueError('SingleValueLabel may only have one value')
+        return self.create_label(values[0])
+
+
+class SecurityLabelHelper:
+    def add(self, label: SingleValueLabel, value: str):
+        """
+        Adds single label expression
+        """
+        raise NotImplementedError()
+
+    def add_multiple(self, label: MultiValueLabel, *values):
+        """
+        Adds a single label expression with multiple values, evaluated usually with OR logic
+        """
+        raise NotImplementedError()
+
+    def add_or_expression(self, expression: str):
+        """
+        Adds an expression as an or, allowing for complex SecurityLabel expressions
+        """
+        raise NotImplementedError()
+
+    def build(self) -> str:
+        raise NotImplementedError()
+
+
+class SecurityLabelBuilder(SecurityLabelHelper):
+    """
+    Core requires all messages to have a security label.
+
+    The Security Label Builder is a helper function to make sure Security Labels created are both valid in terms of
+    syntax and valid in terms of standards
+
+    The base label set is the current created Security Label Expression, the or expressions are a way to chain multiple
+    expressions together e.g
+
+    """
+
+    def __init__(self):
+        self.labels = []
+        self.or_expressions = []
+        self.used_labels = []
+
+    def add(self, label: Label, value: str):
+        if label.name in self.used_labels:
+            print(
+                "WARNING: Be careful adding multiple expressions with the same label - it could make data inaccessible"
+            )
+        else:
+            self.used_labels.append(label.name)
+        self.labels.append(label.construct(value))
+        return self
+
+    def add_multiple(self, label: MultiValueLabel, *values):
+        if label.name in self.used_labels:
+            print(
+                "WARNING: Be careful adding multiple expressions with the same label - it could make data inaccessible"
+            )
+        else:
+            self.used_labels.append(label.name)
+        self.labels.append(label.construct(*values))
+        return self
+
+    def add_or_expression(self, expression: str):
+        trimmed = expression.strip()
+        if trimmed is None or not len(trimmed) >= 2:
+            raise ValueError("Valid security label expression required")
+        if trimmed[0] != "(" or trimmed[-1] != ")":
+            raise ValueError("Valid security label expression should be enclosed "
+                             "with brackets (security-label expression)")
+        self.or_expressions.append(trimmed)
+        return self
+
+    def build(self):
+        open_expression = "("
+        expression = "&".join(self.labels)
+        close_expression = ")" if len(self.or_expressions) == 0 else ")|"
+        base_expression = (
+            ""
+            if len(expression.strip()) == 0
+            else f"{open_expression}{expression}{close_expression}"
+        )
+        ors = "|".join(self.or_expressions)
+        return f"{base_expression}{ors}"

--- a/telicent_labels/security_labels.py
+++ b/telicent_labels/security_labels.py
@@ -55,7 +55,7 @@ class SingleValueLabel(Label):
 
     def construct(self, *values):
         if len(values) > 1:
-            raise ValueError('SingleValueLabel may only have one value')
+            raise ValueError("SingleValueLabel may only have one value")
         return self.create_label(values[0])
 
 
@@ -124,8 +124,9 @@ class SecurityLabelBuilder(SecurityLabelHelper):
         if trimmed is None or not len(trimmed) >= 2:
             raise ValueError("Valid security label expression required")
         if trimmed[0] != "(" or trimmed[-1] != ")":
-            raise ValueError("Valid security label expression should be enclosed "
-                             "with brackets (security-label expression)")
+            raise ValueError(
+                "Valid security label expression should be enclosed " "with brackets (security-label expression)"
+            )
         self.or_expressions.append(trimmed)
         return self
 
@@ -133,10 +134,6 @@ class SecurityLabelBuilder(SecurityLabelHelper):
         open_expression = "("
         expression = "&".join(self.labels)
         close_expression = ")" if len(self.or_expressions) == 0 else ")|"
-        base_expression = (
-            ""
-            if len(expression.strip()) == 0
-            else f"{open_expression}{expression}{close_expression}"
-        )
+        base_expression = "" if len(expression.strip()) == 0 else f"{open_expression}{expression}{close_expression}"
         ors = "|".join(self.or_expressions)
         return f"{base_expression}{ors}"

--- a/telicent_labels/telicent_model.py
+++ b/telicent_labels/telicent_model.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timezone
+from typing import Annotated
+
+from pydantic import AwareDatetime, BaseModel, PlainSerializer
+
+from telicent_labels.security_labels import SecurityLabelBuilder
+from telicent_labels.telicentv2 import TelicentSecurityLabelsV2
+
+__license__ = """
+Copyright (c) Telicent Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+DEFAULT_OPTIONAL_DT = datetime(2023, 12, 14, 0, 0, 0, tzinfo=timezone.utc)
+SerialisableDt = Annotated[AwareDatetime, PlainSerializer(lambda x: x.isoformat(), return_type=str, when_used="always")]
+
+
+class TelicentMixin(BaseModel):
+
+    def build_security_labels(self):
+        builder = SecurityLabelBuilder()
+
+        builder.add(TelicentSecurityLabelsV2.CLASSIFICATION.value, self.classification)
+        builder.add_multiple(TelicentSecurityLabelsV2.PERMITTED_ORGANISATIONS.value, *self.permittedOrgs)
+        builder.add_multiple(TelicentSecurityLabelsV2.PERMITTED_NATIONALITIES.value, *self.permittedNats)
+        builder.add_multiple(TelicentSecurityLabelsV2.AND_GROUPS.value, *self.andGroups)
+        builder.add_multiple(TelicentSecurityLabelsV2.OR_GROUPS.value, *self.orGroups)
+
+        return builder.build()
+
+
+class TelicentModel(TelicentMixin):
+    apiVersion: str | None = "v1alpha"
+    specification: str | None = "UKIC v3.0"
+    identifier: str
+    classification: str
+    permittedOrgs: list[str]
+    permittedNats: list[str]
+    orGroups: list[str]
+    andGroups: list[str]
+
+    createdDateTime: SerialisableDt | None = DEFAULT_OPTIONAL_DT
+    originator: str | None = None
+    custodian: str | None = None
+    policyRef: str | None = None
+    dataSet: list[str]
+    authRef: list[str]
+    dispositionDate: SerialisableDt | None = DEFAULT_OPTIONAL_DT
+    dispositionProcess: str | None = None
+    dissemination: list[str]
+
+    def build_security_labels(self):
+        return super().build_security_labels()

--- a/telicent_labels/telicent_model.py
+++ b/telicent_labels/telicent_model.py
@@ -44,7 +44,7 @@ class TelicentMixin(BaseModel, ABC):
 
 class TelicentModel(TelicentMixin):
     apiVersion: str | None = "v1alpha"
-    specification: str | None = "UKIC v3.0"
+    specification: str | None = "v3.0"
     identifier: str
     classification: str
     permittedOrgs: list[str]

--- a/telicent_labels/telicent_model.py
+++ b/telicent_labels/telicent_model.py
@@ -62,14 +62,15 @@ class TelicentModel(TelicentMixin):
     dispositionProcess: str | None = None
     dissemination: list[str]
 
-    @field_validator('classification')
+    @field_validator("classification")
     def non_empty_string(cls, value: str, info):
         if value.strip() == "":
             raise ValueError(f"The {info.field_name} field cannot be an empty string.")
         return value
 
-    @field_validator('permittedOrgs', 'permittedNats', 'orGroups', 'andGroups', 'dataSet',
-                     'authRef', 'dissemination', mode='before')
+    @field_validator(
+        "permittedOrgs", "permittedNats", "orGroups", "andGroups", "dataSet", "authRef", "dissemination", mode="before"
+    )
     def non_empty_list(cls, value: list[str], info):
         clean_list = [x for x in value if x]
         if not clean_list or len(clean_list) == 0:

--- a/telicent_labels/telicentv1.py
+++ b/telicent_labels/telicentv1.py
@@ -1,0 +1,29 @@
+from enum import Enum
+
+from telicent_labels import security_labels as security
+
+__license__ = """
+Copyright (c) Telicent Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+class TelicentLabelsV1(Enum):
+    """
+    Representation of simplified Telicent model suitable for SecurityLabelbuilder,
+    simplified for the CORE environment
+    """
+    PERMITTED_ORGANISATIONS = security.MultiValueLabel("deployed_organisation", "array")
+    PERMITTED_NATIONALITIES = security.MultiValueLabel("nationality", "array")
+    CLASSIFICATION = security.SingleValueLabel("clearance", "str")

--- a/telicent_labels/telicentv1.py
+++ b/telicent_labels/telicentv1.py
@@ -24,6 +24,7 @@ class TelicentLabelsV1(Enum):
     Representation of simplified Telicent model suitable for SecurityLabelbuilder,
     simplified for the CORE environment
     """
+
     PERMITTED_ORGANISATIONS = security.MultiValueLabel("deployed_organisation", "array")
     PERMITTED_NATIONALITIES = security.MultiValueLabel("nationality", "array")
     CLASSIFICATION = security.SingleValueLabel("clearance", "str")

--- a/telicent_labels/telicentv2.py
+++ b/telicent_labels/telicentv2.py
@@ -1,0 +1,58 @@
+from enum import Enum
+
+from telicent_labels.security_labels import MultiValueLabel, SingleValueLabel
+
+__license__ = """
+Copyright (c) Telicent Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+class AndGroups(MultiValueLabel):
+
+    # Something in here needed to get valid group
+    def construct(self, *values):
+        # assume value is urn
+        condition = "&".join(map(self.create_label, values))
+        return condition
+
+    def create_label(self, value: str):
+        return value + ":and"
+
+
+class OrGroups(MultiValueLabel):
+
+    # Something in here needed to get valid group
+    def construct(self, *values):
+        # assume value is urn
+        condition = "|".join(map(self.create_label, values))
+        return "(" + condition + ")"
+
+    def create_label(self, value: str):
+        return value + ":or"
+
+
+class TelicentSecurityLabelsV2(Enum):
+    """
+    Representation of the Telicent model suitable for SecurityLabelbuilder
+    """
+    PERMITTED_ORGANISATIONS = MultiValueLabel(
+        "permitted_organisations", "array"
+    )
+    PERMITTED_NATIONALITIES = MultiValueLabel(
+        "permitted_nationalities", "array"
+    )
+    CLASSIFICATION = SingleValueLabel("classification", "str")
+    AND_GROUPS = AndGroups("and_groups", "groups")
+    OR_GROUPS = OrGroups("or_groups", "groups")

--- a/telicent_labels/telicentv2.py
+++ b/telicent_labels/telicentv2.py
@@ -20,7 +20,6 @@ limitations under the License.
 
 
 class AndGroups(MultiValueLabel):
-
     # Something in here needed to get valid group
     def construct(self, *values):
         # assume value is urn
@@ -32,7 +31,6 @@ class AndGroups(MultiValueLabel):
 
 
 class OrGroups(MultiValueLabel):
-
     # Something in here needed to get valid group
     def construct(self, *values):
         # assume value is urn
@@ -47,12 +45,9 @@ class TelicentSecurityLabelsV2(Enum):
     """
     Representation of the Telicent model suitable for SecurityLabelbuilder
     """
-    PERMITTED_ORGANISATIONS = MultiValueLabel(
-        "permitted_organisations", "array"
-    )
-    PERMITTED_NATIONALITIES = MultiValueLabel(
-        "permitted_nationalities", "array"
-    )
+
+    PERMITTED_ORGANISATIONS = MultiValueLabel("permitted_organisations", "array")
+    PERMITTED_NATIONALITIES = MultiValueLabel("permitted_nationalities", "array")
     CLASSIFICATION = SingleValueLabel("classification", "str")
     AND_GROUPS = AndGroups("and_groups", "groups")
     OR_GROUPS = OrGroups("or_groups", "groups")

--- a/test/test_idh_model.py
+++ b/test/test_idh_model.py
@@ -15,15 +15,17 @@ class IDHModelTestCase(unittest.TestCase):
                 "classification": "O",
                 "allowedOrgs": ["Telicent"],
                 "allowedNats": ["GBR"],
-                "groups": ["urn:telicent:groups:developer"]
+                "groups": ["urn:telicent:groups:developer"],
             },
-            "ownership":{
-                "originatingOrg": "Telicent"
-            }
+            "ownership": {"originatingOrg": "Telicent"},
         }
-        
+
         security_label = IDHModel(**label).build_security_labels()
-        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR)&urn:telicent:groups:developer:and)")
+        self.assertEqual(
+            security_label,
+            "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR)&urn:telicent:groups:developer:and)",
+        )
+
     def test_simple_label_multi_group(self):
         label = {
             "apiVersion": "v1alpha",
@@ -35,15 +37,17 @@ class IDHModelTestCase(unittest.TestCase):
                 "classification": "O",
                 "allowedOrgs": ["Telicent"],
                 "allowedNats": ["GBR"],
-                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"],
             },
-            "ownership":{
-                "originatingOrg": "Telicent"
-            }
+            "ownership": {"originatingOrg": "Telicent"},
         }
-        
+
         security_label = IDHModel(**label).build_security_labels()
-        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)")
+        self.assertEqual(
+            security_label,
+            "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)",
+        )
+
     def test_simple_label_multi_nationality(self):
         label = {
             "apiVersion": "v1alpha",
@@ -55,15 +59,17 @@ class IDHModelTestCase(unittest.TestCase):
                 "classification": "O",
                 "allowedOrgs": ["Telicent"],
                 "allowedNats": ["GBR", "FRA"],
-                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"],
             },
-            "ownership":{
-                "originatingOrg": "Telicent"
-            }
+            "ownership": {"originatingOrg": "Telicent"},
         }
-        
+
         security_label = IDHModel(**label).build_security_labels()
-        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR|permitted_nationalities=FRA)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)")
+        self.assertEqual(
+            security_label,
+            "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR|permitted_nationalities=FRA)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)",
+        )
+
     def test_simple_label_multi_organisation(self):
         label = {
             "apiVersion": "v1alpha",
@@ -75,15 +81,16 @@ class IDHModelTestCase(unittest.TestCase):
                 "classification": "O",
                 "allowedOrgs": ["Telicent", "NHS"],
                 "allowedNats": ["GBR", "FRA"],
-                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"],
             },
-            "ownership":{
-                "originatingOrg": "Telicent"
-            }
+            "ownership": {"originatingOrg": "Telicent"},
         }
-        
+
         security_label = IDHModel(**label).build_security_labels()
-        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent|permitted_organisations=NHS)&(permitted_nationalities=GBR|permitted_nationalities=FRA)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)")
+        self.assertEqual(
+            security_label,
+            "(classification=O&(permitted_organisations=Telicent|permitted_organisations=NHS)&(permitted_nationalities=GBR|permitted_nationalities=FRA)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)",
+        )
 
     def test_error_label_no_classification(self):
         label = {
@@ -96,16 +103,14 @@ class IDHModelTestCase(unittest.TestCase):
                 "classification": "",
                 "allowedOrgs": ["Telicent", "NHS"],
                 "allowedNats": ["GBR", "FRA"],
-                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"],
             },
-            "ownership":{
-                "originatingOrg": "Telicent"
-            }
+            "ownership": {"originatingOrg": "Telicent"},
         }
         with self.assertRaises(ValueError) as context:
             IDHModel(**label)
-        self.assertTrue("The classification field cannot be an empty string" in str(context.exception) )
-     
+        self.assertTrue("The classification field cannot be an empty string" in str(context.exception))
+
     def test_error_label_wrong_classification(self):
         label = {
             "apiVersion": "v1alpha",
@@ -117,16 +122,14 @@ class IDHModelTestCase(unittest.TestCase):
                 "classification": "P",
                 "allowedOrgs": ["Telicent", "NHS"],
                 "allowedNats": ["GBR", "FRA"],
-                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"],
             },
-            "ownership":{
-                "originatingOrg": "Telicent"
-            }
+            "ownership": {"originatingOrg": "Telicent"},
         }
         with self.assertRaises(ValueError) as context:
             IDHModel(**label)
-        self.assertTrue("The classification field must be 'O', 'OS', 'S' or 'TS'." in str(context.exception) )
-    
+        self.assertTrue("The classification field must be 'O', 'OS', 'S' or 'TS'." in str(context.exception))
+
     def test_simple_label_only_classification(self):
         label = {
             "apiVersion": "v1alpha",
@@ -134,17 +137,10 @@ class IDHModelTestCase(unittest.TestCase):
             "creationDate": "2024-09-27 00:00:00+00:00",
             "containsPii": False,
             "dataSource": "Tom Test",
-            "access": {
-                "classification": "O",
-                "allowedOrgs": [],
-                "allowedNats": [],
-                "groups": []
-            },
-            "ownership":{
-                "originatingOrg": "Telicent"
-            }
+            "access": {"classification": "O", "allowedOrgs": [], "allowedNats": [], "groups": []},
+            "ownership": {"originatingOrg": "Telicent"},
         }
-        
+
         security_label = IDHModel(**label).build_security_labels()
         self.assertEqual(security_label, "(classification=O)")
 
@@ -157,17 +153,13 @@ class IDHModelTestCase(unittest.TestCase):
             "dataSource": "Tom Test",
             "access": {
                 "classification": "O",
-                
             },
-            "ownership":{
-                "originatingOrg": "Telicent"
-            }
+            "ownership": {"originatingOrg": "Telicent"},
         }
-        
+
         with self.assertRaises(ValueError) as context:
             IDHModel(**label)
-      
-        self.assertTrue("access.allowedNats" in str(context.exception) )
-        self.assertTrue("access.allowedOrgs" in str(context.exception) )
-        self.assertTrue("access.groups" in str(context.exception) )
-    
+
+        self.assertTrue("access.allowedNats" in str(context.exception))
+        self.assertTrue("access.allowedOrgs" in str(context.exception))
+        self.assertTrue("access.groups" in str(context.exception))

--- a/test/test_idh_model.py
+++ b/test/test_idh_model.py
@@ -1,0 +1,173 @@
+import unittest
+
+from telicent_labels import IDHModel
+
+
+class IDHModelTestCase(unittest.TestCase):
+    def test_simple_label(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": ["Telicent"],
+                "allowedNats": ["GBR"],
+                "groups": ["urn:telicent:groups:developer"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR)&urn:telicent:groups:developer:and)")
+    def test_simple_label_multi_group(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": ["Telicent"],
+                "allowedNats": ["GBR"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)")
+    def test_simple_label_multi_nationality(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": ["Telicent"],
+                "allowedNats": ["GBR", "FRA"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&(permitted_nationalities=GBR|permitted_nationalities=FRA)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)")
+    def test_simple_label_multi_organisation(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": ["Telicent", "NHS"],
+                "allowedNats": ["GBR", "FRA"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent|permitted_organisations=NHS)&(permitted_nationalities=GBR|permitted_nationalities=FRA)&urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)")
+
+    def test_error_label_no_classification(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "",
+                "allowedOrgs": ["Telicent", "NHS"],
+                "allowedNats": ["GBR", "FRA"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        with self.assertRaises(ValueError) as context:
+            IDHModel(**label)
+        self.assertTrue("The classification field cannot be an empty string" in str(context.exception) )
+     
+    def test_error_label_wrong_classification(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "P",
+                "allowedOrgs": ["Telicent", "NHS"],
+                "allowedNats": ["GBR", "FRA"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        with self.assertRaises(ValueError) as context:
+            IDHModel(**label)
+        self.assertTrue("The classification field must be 'O', 'OS', 'S' or 'TS'." in str(context.exception) )
+    
+    def test_simple_label_only_classification(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": [],
+                "allowedNats": [],
+                "groups": []
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O)")
+
+    def test_error_label_missing_fields(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        
+        with self.assertRaises(ValueError) as context:
+            IDHModel(**label)
+      
+        self.assertTrue("access.allowedNats" in str(context.exception) )
+        self.assertTrue("access.allowedOrgs" in str(context.exception) )
+        self.assertTrue("access.groups" in str(context.exception) )
+    

--- a/test/test_security_labels.py
+++ b/test/test_security_labels.py
@@ -1,0 +1,182 @@
+import unittest
+
+from telicent_labels import SecurityLabelBuilder, TelicentSecurityLabelsV2
+from telicent_labels.security_labels import Label
+
+
+class SecurityLabelBuilderTestCase(unittest.TestCase):
+    def test_simple_and_group_label_access(self):
+        pn = TelicentSecurityLabelsV2.AND_GROUPS.value
+        test_group_1 = "urn:telicent:groups:role:doctor"
+        test_group_2 = "urn:telicent:groups:role:admin"
+
+        basic_label = pn.create_label(test_group_1)
+
+        self.assertEqual(basic_label, "urn:telicent:groups:role:doctor:and")
+
+        single_group = pn.construct(test_group_1)
+
+        self.assertEqual(single_group, "urn:telicent:groups:role:doctor:and")
+
+        multi_group = pn.construct(test_group_1, test_group_2)
+
+        self.assertEqual(
+            multi_group,
+            "urn:telicent:groups:role:doctor:and&urn:telicent:groups:role:admin:and",
+        )
+
+    def test_simple_or_group_label_access(self):
+        pn = TelicentSecurityLabelsV2.OR_GROUPS.value
+        test_group_1 = "urn:telicent:groups:role:doctor"
+        test_group_2 = "urn:telicent:groups:role:admin"
+
+        basic_label = pn.create_label(test_group_1)
+
+        self.assertEqual(basic_label, "urn:telicent:groups:role:doctor:or")
+
+        single_group = pn.construct(test_group_1)
+
+        self.assertEqual(single_group, "(urn:telicent:groups:role:doctor:or)")
+
+        multi_group = pn.construct(test_group_1, test_group_2)
+
+        self.assertEqual(
+            multi_group,
+            "(urn:telicent:groups:role:doctor:or|urn:telicent:groups:role:admin:or)",
+        )
+
+    def test_simple_single_label_access(self):
+        pn = TelicentSecurityLabelsV2.CLASSIFICATION.value
+        test_classifcation = "S"
+
+        basic_label = pn.create_label(test_classifcation)
+
+        self.assertEqual(basic_label, "classification=S")
+
+        multi_label = pn.construct(test_classifcation)
+
+        self.assertEqual(multi_label, "classification=S")
+
+    def test_simple_multi_label_access(self):
+        pn = TelicentSecurityLabelsV2.PERMITTED_NATIONALITIES.value
+        test_nationality_1 = "GBR"
+        test_nationality_2 = "NOR"
+        basic_label = pn.create_label(test_nationality_1)
+
+        self.assertEqual(basic_label, "permitted_nationalities=GBR")
+
+        multi_label = pn.construct(test_nationality_1, test_nationality_2)
+
+        self.assertEqual(
+            multi_label, "(permitted_nationalities=GBR|permitted_nationalities=NOR)"
+        )
+
+    def test_security_label_builder(self):
+        test_org_1 = "telicent"
+        test_org_2 = "nhs"
+        test_classification = "S"
+        test_classification_1 = "O"
+        slb1 = (
+            SecurityLabelBuilder()
+            .add_multiple(
+                TelicentSecurityLabelsV2.PERMITTED_ORGANISATIONS.value,
+                test_org_1,
+                test_org_2,
+            )
+            .add(TelicentSecurityLabelsV2.CLASSIFICATION.value, test_classification)
+            .build()
+        )
+        self.assertEqual(
+            slb1,
+            "((permitted_organisations=telicent|permitted_organisations=nhs)&classification=S)",
+        )
+
+        slb2 = (
+            SecurityLabelBuilder()
+            .add(TelicentSecurityLabelsV2.PERMITTED_ORGANISATIONS.value, test_org_1)
+            .add(TelicentSecurityLabelsV2.CLASSIFICATION.value, test_classification_1)
+            .build()
+        )
+
+        self.assertEqual(
+            slb2,
+            "((permitted_organisations=telicent)&classification=O)",
+        )
+
+        slb3 = (
+            SecurityLabelBuilder()
+            .add_or_expression(slb1)
+            .add_or_expression(slb2)
+            .build()
+        )
+
+        self.assertEqual(
+            slb3,
+            "((permitted_organisations=telicent|permitted_organisations=nhs)&classification=S)|"
+            "((permitted_organisations=telicent)&classification=O)",
+        )
+
+        slb4 = (
+            SecurityLabelBuilder()
+            .add_multiple(
+                TelicentSecurityLabelsV2.PERMITTED_ORGANISATIONS.value,
+                test_org_1,
+                test_org_2,
+            )
+            .add(TelicentSecurityLabelsV2.CLASSIFICATION.value, test_classification)
+            .add_or_expression(slb2)
+            .build()
+        )
+
+        self.assertEqual(
+            slb4,
+            "((permitted_organisations=telicent|permitted_organisations=nhs)&classification=S)|"
+            "((permitted_organisations=telicent)&classification=O)",
+        )
+
+    def test_security_label_builder_complex(self):
+        test_org_1 = "nhs"
+        test_classification = "S"
+        test_and_group = "urn:telicent:groups:department:vulnerable_care"
+        test_or_group_1 = "urn:telicent:groups:role:admin"
+        test_or_group_2 = "urn:telicent:groups:role:doctor"
+        test_nationality_1 = "GBR"
+        test_nationality_2 = "USA"
+
+        slb = (
+            SecurityLabelBuilder()
+            .add(TelicentSecurityLabelsV2.PERMITTED_ORGANISATIONS.value, test_org_1)
+            .add(TelicentSecurityLabelsV2.CLASSIFICATION.value, test_classification)
+            .add_multiple(
+                TelicentSecurityLabelsV2.OR_GROUPS.value, test_or_group_1, test_or_group_2
+            )
+            .add(TelicentSecurityLabelsV2.AND_GROUPS.value, test_and_group)
+            .add_multiple(
+                TelicentSecurityLabelsV2.PERMITTED_NATIONALITIES.value,
+                test_nationality_1,
+                test_nationality_2,
+            )
+            .build()
+        )
+        self.assertEqual(
+            slb,
+            "((permitted_organisations=nhs)&classification=S&(urn:telicent:groups:role:admin:or|"
+            "urn:telicent:groups:role:doctor:or)&urn:telicent:groups:department:vulnerable_care:and&"
+            "(permitted_nationalities=GBR|permitted_nationalities=USA))",
+        )
+
+    def test_base_label_error(self):
+        self.assertRaises(
+            NotImplementedError,
+            SecurityLabelBuilder().add,
+            Label("test", "str"),
+            "test",
+        )
+
+        self.assertRaises(
+            NotImplementedError,
+            SecurityLabelBuilder().add_multiple,
+            Label("test", "str"),
+            "test1",
+            "test2",
+        )

--- a/test/test_security_labels.py
+++ b/test/test_security_labels.py
@@ -67,9 +67,7 @@ class SecurityLabelBuilderTestCase(unittest.TestCase):
 
         multi_label = pn.construct(test_nationality_1, test_nationality_2)
 
-        self.assertEqual(
-            multi_label, "(permitted_nationalities=GBR|permitted_nationalities=NOR)"
-        )
+        self.assertEqual(multi_label, "(permitted_nationalities=GBR|permitted_nationalities=NOR)")
 
     def test_security_label_builder(self):
         test_org_1 = "telicent"
@@ -103,12 +101,7 @@ class SecurityLabelBuilderTestCase(unittest.TestCase):
             "((permitted_organisations=telicent)&classification=O)",
         )
 
-        slb3 = (
-            SecurityLabelBuilder()
-            .add_or_expression(slb1)
-            .add_or_expression(slb2)
-            .build()
-        )
+        slb3 = SecurityLabelBuilder().add_or_expression(slb1).add_or_expression(slb2).build()
 
         self.assertEqual(
             slb3,
@@ -147,9 +140,7 @@ class SecurityLabelBuilderTestCase(unittest.TestCase):
             SecurityLabelBuilder()
             .add(TelicentSecurityLabelsV2.PERMITTED_ORGANISATIONS.value, test_org_1)
             .add(TelicentSecurityLabelsV2.CLASSIFICATION.value, test_classification)
-            .add_multiple(
-                TelicentSecurityLabelsV2.OR_GROUPS.value, test_or_group_1, test_or_group_2
-            )
+            .add_multiple(TelicentSecurityLabelsV2.OR_GROUPS.value, test_or_group_1, test_or_group_2)
             .add(TelicentSecurityLabelsV2.AND_GROUPS.value, test_and_group)
             .add_multiple(
                 TelicentSecurityLabelsV2.PERMITTED_NATIONALITIES.value,

--- a/test/test_security_labels_telicent_model.py
+++ b/test/test_security_labels_telicent_model.py
@@ -1,0 +1,115 @@
+import unittest
+
+from telicent_labels import SecurityLabelBuilder, TelicentLabelsV1
+
+
+class SecurityLabelBuilderTestCase(unittest.TestCase):
+    def test_simple_single_label_access(self):
+        pn = TelicentLabelsV1.CLASSIFICATION.value
+        test_classifcation = "S"
+
+        basic_label = pn.create_label(test_classifcation)
+
+        self.assertEqual(basic_label, "clearance=S")
+
+        multi_label = pn.construct(test_classifcation)
+
+        self.assertEqual(multi_label, "clearance=S")
+
+    def test_simple_multi_label_access(self):
+        pn = TelicentLabelsV1.PERMITTED_NATIONALITIES.value
+        test_nationality_1 = "GBR"
+        test_nationality_2 = "NOR"
+        basic_label = pn.create_label(test_nationality_1)
+
+        self.assertEqual(basic_label, "nationality=GBR")
+
+        multi_label = pn.construct(test_nationality_1, test_nationality_2)
+
+        self.assertEqual(multi_label, "(nationality=GBR|nationality=NOR)")
+
+    def test_security_label_builder(self):
+        test_org_1 = "telicent"
+        test_org_2 = "nhs"
+        test_classification = "S"
+        test_classification_1 = "O"
+        slb1 = (
+            SecurityLabelBuilder()
+            .add_multiple(
+                TelicentLabelsV1.PERMITTED_ORGANISATIONS.value,
+                test_org_1,
+                test_org_2,
+            )
+            .add(TelicentLabelsV1.CLASSIFICATION.value, test_classification)
+            .build()
+        )
+        self.assertEqual(
+            slb1,
+            "((deployed_organisation=telicent|deployed_organisation=nhs)&clearance=S)",
+        )
+
+        slb2 = (
+            SecurityLabelBuilder()
+            .add(TelicentLabelsV1.PERMITTED_ORGANISATIONS.value, test_org_1)
+            .add(TelicentLabelsV1.CLASSIFICATION.value, test_classification_1)
+            .build()
+        )
+
+        self.assertEqual(
+            slb2,
+            "((deployed_organisation=telicent)&clearance=O)",
+        )
+
+        slb3 = (
+            SecurityLabelBuilder()
+            .add_or_expression(slb1)
+            .add_or_expression(slb2)
+            .build()
+        )
+
+        self.assertEqual(
+            slb3,
+            "((deployed_organisation=telicent|deployed_organisation=nhs)&clearance=S)|"
+            "((deployed_organisation=telicent)&clearance=O)",
+        )
+
+        slb4 = (
+            SecurityLabelBuilder()
+            .add_multiple(
+                TelicentLabelsV1.PERMITTED_ORGANISATIONS.value,
+                test_org_1,
+                test_org_2,
+            )
+            .add(TelicentLabelsV1.CLASSIFICATION.value, test_classification)
+            .add_or_expression(slb2)
+            .build()
+        )
+
+        self.assertEqual(
+            slb4,
+            "((deployed_organisation=telicent|deployed_organisation=nhs)&clearance=S)|"
+            "((deployed_organisation=telicent)&clearance=O)",
+        )
+
+    def test_security_label_builder_complex(self):
+        test_org_1 = "nhs"
+        test_classification = "S"
+
+        test_nationality_1 = "GBR"
+        test_nationality_2 = "USA"
+
+        slb = (
+            SecurityLabelBuilder()
+            .add(TelicentLabelsV1.PERMITTED_ORGANISATIONS.value, test_org_1)
+            .add(TelicentLabelsV1.CLASSIFICATION.value, test_classification)
+            .add_multiple(
+                TelicentLabelsV1.PERMITTED_NATIONALITIES.value,
+                test_nationality_1,
+                test_nationality_2,
+            )
+            .build()
+        )
+        self.assertEqual(
+            slb,
+            "((deployed_organisation=nhs)&clearance=S&(nationality=GBR|nationality=USA))",
+        )

--- a/test/test_security_labels_telicent_model.py
+++ b/test/test_security_labels_telicent_model.py
@@ -60,12 +60,7 @@ class SecurityLabelBuilderTestCase(unittest.TestCase):
             "((deployed_organisation=telicent)&clearance=O)",
         )
 
-        slb3 = (
-            SecurityLabelBuilder()
-            .add_or_expression(slb1)
-            .add_or_expression(slb2)
-            .build()
-        )
+        slb3 = SecurityLabelBuilder().add_or_expression(slb1).add_or_expression(slb2).build()
 
         self.assertEqual(
             slb3,


### PR DESCRIPTION
IDH is a new data header standard which we are going to use a bit of internally - initially for the Federation demo. 

This created a mixin where the policy information object is passed and then returned as a CORE, rdf-abac security label which is compatible with Access. 

This is the object structure 
```
/*
idh: {
    "apiVersion": "", 
    "uuid": "", Unique ID for 
    "creationDate": "",
    "containsPii": true/false
    "dataSource": "..." // Optional
    "ownership": {
        originatingOrg: "",
        user: "" // Optional
    }
    "access": {
        "classification": ".." >>> O, OS, etc. ---> maps to classification
        "allowedOrgs": [...], ----> maps to permitted_organisations
        "allowedNats": [...], ----> maps to permitted_nationalities
        "groups": [...], >>> AND GROUPS ONLY ----> maps to AND Groups
    }
}
*/
```


