### PR TITLE
feat: add initial view of the idh model mixin for label creation

### DIFF
--- a/telicent_labels/__init__.py
+++ b/telicent_labels/__init__.py
@@ -1,3 +1,4 @@
+from telicent_labels.idh_model import IDHModel
 from telicent_labels.security_labels import Label, MultiValueLabel, SecurityLabelBuilder, SingleValueLabel
 from telicent_labels.telicent_model import TelicentModel
 from telicent_labels.telicentv1 import TelicentLabelsV1
@@ -28,4 +29,5 @@ __all__ = [
     "SingleValueLabel",
     "Label",
     "TelicentModel",
+    "IDHModel"
 ]

--- a/telicent_labels/idh_model.py
+++ b/telicent_labels/idh_model.py
@@ -1,0 +1,79 @@
+import logging
+from datetime import datetime, timezone
+from typing import Annotated
+
+from pydantic import AwareDatetime, BaseModel, PlainSerializer, field_validator
+
+from telicent_labels.security_labels import SecurityLabelBuilder
+from telicent_labels.telicentv2 import TelicentSecurityLabelsV2
+
+__license__ = """
+Copyright (c) Telicent Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+log = logging.getLogger(__name__)
+
+DEFAULT_OPTIONAL_DT = datetime(2023, 12, 14, 0, 0, 0, tzinfo=timezone.utc)
+SerialisableDt = Annotated[AwareDatetime, PlainSerializer(lambda x: x.isoformat(), return_type=str, when_used="always")]
+
+
+class TelicentMixin(BaseModel):
+    def build_security_labels(self):
+        print(self.creationDate)
+        builder = SecurityLabelBuilder()
+
+        builder.add(TelicentSecurityLabelsV2.CLASSIFICATION.value, self.access.classification)
+        if len(self.access.allowedOrgs) > 0:
+            builder.add_multiple(TelicentSecurityLabelsV2.PERMITTED_ORGANISATIONS.value, *self.access.allowedOrgs)
+        if len(self.access.allowedNats) > 0:
+            builder.add_multiple(TelicentSecurityLabelsV2.PERMITTED_NATIONALITIES.value, *self.access.allowedNats)
+        if len(self.access.groups) > 0:
+            builder.add_multiple(TelicentSecurityLabelsV2.AND_GROUPS.value, *self.access.groups)
+
+        return builder.build()
+
+
+
+class AccessModel(BaseModel):
+    classification: str
+    allowedOrgs: list[str]
+    allowedNats: list[str]
+    groups: list[str]
+
+    @field_validator('classification')
+    def non_empty_string(cls, value: str, info):
+        if value.strip() == "":
+            raise ValueError(f"The {info.field_name} field cannot be an empty string.")
+        if value.strip() not in ("O", "OS", "S", "TS"):
+            raise ValueError(f"The {info.field_name} field must be 'O', 'OS', 'S' or 'TS'.")
+        return value
+
+
+class OwnershipModel(BaseModel):
+    originatingOrg: str
+    user: str | None = None
+
+class IDHModel(TelicentMixin):
+
+    apiVersion: str | None = "v1alpha"
+    uuid: str
+    creationDate: SerialisableDt | None = DEFAULT_OPTIONAL_DT
+    containsPii: bool
+    dataSource: str | None = None
+    ownership: OwnershipModel
+    access: AccessModel
+
+    def build_security_labels(self):
+        return super().build_security_labels()

--- a/test/test_idh_model.py
+++ b/test/test_idh_model.py
@@ -1,0 +1,180 @@
+import unittest
+
+from telicent_labels import IDHModel
+
+
+class IDHModelTestCase(unittest.TestCase):
+    def test_simple_label(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": ["Telicent"],
+                "allowedNats": ["GBR"],
+                "groups": ["urn:telicent:groups:developer"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&"
+                                         "(permitted_nationalities=GBR)&urn:telicent:groups:developer:and)")
+    def test_simple_label_multi_group(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": ["Telicent"],
+                "allowedNats": ["GBR"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&"
+                                         "(permitted_nationalities=GBR)&urn:telicent:groups:developer:and&"
+                                         "urn:telicent:groups:africa:and)")
+    def test_simple_label_multi_nationality(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": ["Telicent"],
+                "allowedNats": ["GBR", "FRA"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O&(permitted_organisations=Telicent)&"
+                                         "(permitted_nationalities=GBR|permitted_nationalities=FRA)&"
+                                         "urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)")
+    def test_simple_label_multi_organisation(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": ["Telicent", "NHS"],
+                "allowedNats": ["GBR", "FRA"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O&"
+                                         "(permitted_organisations=Telicent|permitted_organisations=NHS)&"
+                                         "(permitted_nationalities=GBR|permitted_nationalities=FRA)&"
+                                         "urn:telicent:groups:developer:and&urn:telicent:groups:africa:and)")
+
+    def test_error_label_no_classification(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "",
+                "allowedOrgs": ["Telicent", "NHS"],
+                "allowedNats": ["GBR", "FRA"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        with self.assertRaises(ValueError) as context:
+            IDHModel(**label)
+        self.assertTrue("The classification field cannot be an empty string" in str(context.exception) )
+
+    def test_error_label_wrong_classification(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "P",
+                "allowedOrgs": ["Telicent", "NHS"],
+                "allowedNats": ["GBR", "FRA"],
+                "groups": ["urn:telicent:groups:developer", "urn:telicent:groups:africa"]
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+        with self.assertRaises(ValueError) as context:
+            IDHModel(**label)
+        self.assertTrue("The classification field must be 'O', 'OS', 'S' or 'TS'." in str(context.exception) )
+
+    def test_simple_label_only_classification(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+                "allowedOrgs": [],
+                "allowedNats": [],
+                "groups": []
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+
+        security_label = IDHModel(**label).build_security_labels()
+        self.assertEqual(security_label, "(classification=O)")
+
+    def test_error_label_missing_fields(self):
+        label = {
+            "apiVersion": "v1alpha",
+            "uuid": "test_Abc_123",
+            "creationDate": "2024-09-27 00:00:00+00:00",
+            "containsPii": False,
+            "dataSource": "Tom Test",
+            "access": {
+                "classification": "O",
+
+            },
+            "ownership":{
+                "originatingOrg": "Telicent"
+            }
+        }
+
+        with self.assertRaises(ValueError) as context:
+            IDHModel(**label)
+
+        self.assertTrue("access.allowedNats" in str(context.exception) )
+        self.assertTrue("access.allowedOrgs" in str(context.exception) )
+        self.assertTrue("access.groups" in str(context.exception) )


### PR DESCRIPTION
IDH is a new data header standard which we are going to use a bit of internally - initially for the Federation demo. 

This created a mixin where the policy information object is passed and then returned as a CORE, rdf-abac security label which is compatible with Access. 

This is the object structure 
```
/*
idh: {
    "apiVersion": "", 
    "uuid": "", Unique ID for 
    "creationDate": "",
    "containsPii": true/false
    "dataSource": "..." // Optional
    "ownership": {
        originatingOrg: "",
        user: "" // Optional
    }
    "access": {
        "classification": ".." >>> O, OS, etc. ---> maps to classification
        "allowedOrgs": [...], ----> maps to permitted_organisations
        "allowedNats": [...], ----> maps to permitted_nationalities
        "groups": [...], >>> AND GROUPS ONLY ----> maps to AND Groups
    }
}
*/
```


